### PR TITLE
fix: IDP-1830-Modified QueueCommandOperationDTO, added OnboardingRankingRequestsRepositoryExtended deletePaged method, modified JUnit tests

### DIFF
--- a/src/main/java/it/gov/pagopa/ranking/dto/event/QueueCommandOperationDTO.java
+++ b/src/main/java/it/gov/pagopa/ranking/dto/event/QueueCommandOperationDTO.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Data
 @Builder
@@ -12,5 +13,6 @@ public class QueueCommandOperationDTO {
    private String operationType;
    private String entityId;
    private LocalDateTime operationTime;
+   private Map<String, String> additionalParams;
 
 }

--- a/src/main/java/it/gov/pagopa/ranking/repository/OnboardingRankingRequestsRepository.java
+++ b/src/main/java/it/gov/pagopa/ranking/repository/OnboardingRankingRequestsRepository.java
@@ -16,6 +16,4 @@ public interface OnboardingRankingRequestsRepository extends MongoRepository<Onb
     List<OnboardingRankingRequests> findAllByOrganizationIdAndInitiativeId(String organizationId, String initiativeId);
 
     List<OnboardingRankingRequests> findAllByInitiativeId(String initiativeId, Pageable pageable);
-
-    List<OnboardingRankingRequests> deleteByInitiativeId(String initiativeId);
 }

--- a/src/main/java/it/gov/pagopa/ranking/repository/OnboardingRankingRequestsRepositoryExtended.java
+++ b/src/main/java/it/gov/pagopa/ranking/repository/OnboardingRankingRequestsRepositoryExtended.java
@@ -5,6 +5,9 @@ import it.gov.pagopa.ranking.model.OnboardingRankingRequests;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface OnboardingRankingRequestsRepositoryExtended {
     Page<OnboardingRankingRequests> findAllBy(String initiativeId, RankingRequestFilter filter, Pageable pageable);
+    List<OnboardingRankingRequests> deletePaged(String initiativeId, int pageSize);
 }

--- a/src/main/java/it/gov/pagopa/ranking/repository/OnboardingRankingRequestsRepositoryExtendedImpl.java
+++ b/src/main/java/it/gov/pagopa/ranking/repository/OnboardingRankingRequestsRepositoryExtendedImpl.java
@@ -2,8 +2,11 @@ package it.gov.pagopa.ranking.repository;
 
 import it.gov.pagopa.ranking.dto.controller.RankingRequestFilter;
 import it.gov.pagopa.ranking.model.OnboardingRankingRequests;
+import it.gov.pagopa.ranking.model.OnboardingRankingRequests.Fields;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -12,6 +15,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 public class OnboardingRankingRequestsRepositoryExtendedImpl implements OnboardingRankingRequestsRepositoryExtended {
 
     private final MongoTemplate mongoTemplate;
@@ -32,6 +36,16 @@ public class OnboardingRankingRequestsRepositoryExtendedImpl implements Onboardi
         List<OnboardingRankingRequests> onboardingRankingRequests = mongoTemplate.find(query.with(pageable), OnboardingRankingRequests.class);
         // Convert in pageable
         return new PageImpl<>(onboardingRankingRequests, pageable, count);
+    }
+
+    @Override
+    public List<OnboardingRankingRequests> deletePaged(String initiativeId, int pageSize) {
+        log.trace("[DELETE_PAGED] Deleting onboarding ranking requests in pages");
+        Pageable pageable = PageRequest.of(0, pageSize);
+        return mongoTemplate.findAllAndRemove(
+                Query.query(Criteria.where(Fields.initiativeId).is(initiativeId)).with(pageable),
+                OnboardingRankingRequests.class
+        );
     }
 
     private Criteria getCriteria(String initiativeId, RankingRequestFilter filters) {

--- a/src/main/java/it/gov/pagopa/ranking/service/OnboardingRankingRequestsService.java
+++ b/src/main/java/it/gov/pagopa/ranking/service/OnboardingRankingRequestsService.java
@@ -6,6 +6,5 @@ import java.util.List;
 
 public interface OnboardingRankingRequestsService {
     OnboardingRankingRequests save(OnboardingRankingRequests onboardingRankingRequests);
-
-    List<OnboardingRankingRequests> deleteByInitiativeId(String initiativeId);
+    List<OnboardingRankingRequests> deletePaged(String initiativeId, int pageSize);
 }

--- a/src/main/java/it/gov/pagopa/ranking/service/OnboardingRankingRequestsServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/ranking/service/OnboardingRankingRequestsServiceImpl.java
@@ -20,7 +20,7 @@ public class OnboardingRankingRequestsServiceImpl implements OnboardingRankingRe
     }
 
     @Override
-    public List<OnboardingRankingRequests> deleteByInitiativeId(String initiativeId) {
-        return onboardingRankingRequestsRepository.deleteByInitiativeId(initiativeId);
+    public List<OnboardingRankingRequests> deletePaged(String initiativeId, int pageSize) {
+        return onboardingRankingRequestsRepository.deletePaged(initiativeId, pageSize);
     }
 }

--- a/src/main/java/it/gov/pagopa/ranking/service/initiative/InitiativePersistenceMediator.java
+++ b/src/main/java/it/gov/pagopa/ranking/service/initiative/InitiativePersistenceMediator.java
@@ -5,6 +5,5 @@ import org.springframework.messaging.Message;
 
 public interface InitiativePersistenceMediator {
     void execute(Message<String> message);
-
     void processCommand(QueueCommandOperationDTO queueCommandOperationDTO);
 }

--- a/src/main/java/it/gov/pagopa/ranking/service/initiative/InitiativePersistenceMediatorImpl.java
+++ b/src/main/java/it/gov/pagopa/ranking/service/initiative/InitiativePersistenceMediatorImpl.java
@@ -16,12 +16,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
 @Service
 @Slf4j
+@SuppressWarnings("BusyWait")
 public class InitiativePersistenceMediatorImpl extends BaseKafkaConsumer<InitiativeBuildDTO> implements InitiativePersistenceMediator {
     private final InitiativeBuild2ConfigMapper initiativeBuild2ConfigMapper;
     private final InitiativeConfigService initiativeConfigService;
@@ -31,6 +33,8 @@ public class InitiativePersistenceMediatorImpl extends BaseKafkaConsumer<Initiat
     private final ObjectReader objectReader;
     private final AuditUtilities auditUtilities;
     public static final String SERVICE_COMMAND_DELETE_INITIATIVE = "DELETE_INITIATIVE";
+    private static final String PAGINATION_KEY = "pagination";
+    private static final String DELAY_KEY = "delay";
 
     public InitiativePersistenceMediatorImpl(@Value("${spring.application.name}")String applicationName,
                                              InitiativeBuild2ConfigMapper initiativeBuild2ConfigMapper,
@@ -88,7 +92,6 @@ public class InitiativePersistenceMediatorImpl extends BaseKafkaConsumer<Initiat
         if ((SERVICE_COMMAND_DELETE_INITIATIVE).equals(queueCommandOperationDTO.getOperationType())) {
             long startTime = System.currentTimeMillis();
             Optional<InitiativeConfig> deletedInitiativeConfig = initiativeConfigService.deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
-            List<OnboardingRankingRequests> deletedOnboardingRankingRequestes = onboardingRankingRequestsService.deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
 
             if (deletedInitiativeConfig.isEmpty()){
                 log.info("[DELETE_INITIATIVE] Initiative ranking rule for initiativeId {} was not found", queueCommandOperationDTO.getEntityId());
@@ -97,8 +100,25 @@ public class InitiativePersistenceMediatorImpl extends BaseKafkaConsumer<Initiat
                 auditUtilities.logDeleteInitiativeConfig(queueCommandOperationDTO.getEntityId());
             }
 
+            List<OnboardingRankingRequests> deletedOnboardingRankingRequests = new ArrayList<>();
+            List<OnboardingRankingRequests> fetchedOnboardingRankingRequests;
+
+            do {
+                fetchedOnboardingRankingRequests = onboardingRankingRequestsService.deletePaged(queueCommandOperationDTO.getEntityId(),
+                        Integer.parseInt(queueCommandOperationDTO.getAdditionalParams().get(PAGINATION_KEY)));
+                deletedOnboardingRankingRequests.addAll(fetchedOnboardingRankingRequests);
+                try{
+                    Thread.sleep(Long.parseLong(queueCommandOperationDTO.getAdditionalParams().get(DELAY_KEY)));
+                } catch (InterruptedException e){
+                    log.error("An error has occurred while waiting {}", e.getMessage());
+                    Thread.currentThread().interrupt();
+                }
+            } while (fetchedOnboardingRankingRequests.size() == (Integer.parseInt(queueCommandOperationDTO.getAdditionalParams().get(PAGINATION_KEY))));
+
+
+            List<String> usersId = deletedOnboardingRankingRequests.stream().map(OnboardingRankingRequests::getUserId).distinct().toList();
             log.info("[DELETE_INITIATIVE] Deleted initiative {} from collection: onboarding_ranking_requests", queueCommandOperationDTO.getEntityId());
-            deletedOnboardingRankingRequestes.forEach(deletedOnboardingRankingRequest -> auditUtilities.logDeleteInitiativeRanking(deletedOnboardingRankingRequest.getUserId(), deletedOnboardingRankingRequest.getInitiativeId()));
+            usersId.forEach(userId -> auditUtilities.logDeleteInitiativeRanking(userId, queueCommandOperationDTO.getEntityId()));
             log.info(
                     "[PERFORMANCE_LOG] [{}] Time occurred to perform business logic: {} ms on initiativeId: {}",
                     SERVICE_COMMAND_DELETE_INITIATIVE,

--- a/src/test/java/it/gov/pagopa/ranking/repository/OnboardingRankingRequestsRepositoryExtendedImplTest.java
+++ b/src/test/java/it/gov/pagopa/ranking/repository/OnboardingRankingRequestsRepositoryExtendedImplTest.java
@@ -168,6 +168,20 @@ class OnboardingRankingRequestsRepositoryExtendedImplTest extends BaseIntegratio
         Assertions.assertFalse(result.isEmpty());
         Assertions.assertEquals(listOfUserExpected, result.getContent());
     }
+
+    @Test
+    void deletePaged (){
+        // Given
+        int pageSize = 100;
+
+        // When
+        List<OnboardingRankingRequests> result = repository.deletePaged(TEST_INITIATIVE_ID, pageSize);
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(11, result.size());
+    }
+
     private void checkFindAllResult(Page<OnboardingRankingRequests> result) {
         for(OnboardingRankingRequests r : result) {
             Assertions.assertNotNull(r);

--- a/src/test/java/it/gov/pagopa/ranking/service/OnboardingRankingRequestsServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/ranking/service/OnboardingRankingRequestsServiceImplTest.java
@@ -40,13 +40,14 @@ class OnboardingRankingRequestsServiceImplTest {
         OnboardingRankingRequestsService onboardingRankingRequestsService = new OnboardingRankingRequestsServiceImpl(onboardingRankingRequestsRepositoryMock);
 
         String initiativeId = "InitiativeId";
+        int pageSize = 100;
         OnboardingRankingRequests onboardingRankingRequest = OnboardingRankingRequestsFaker.mockInstance(1);
         onboardingRankingRequest.setInitiativeId(initiativeId);
-        Mockito.when(onboardingRankingRequestsRepositoryMock.deleteByInitiativeId(Mockito.any()))
+        Mockito.when(onboardingRankingRequestsRepositoryMock.deletePaged(initiativeId, pageSize))
                         .thenReturn(List.of(onboardingRankingRequest));
 
         // When
-        List<OnboardingRankingRequests> result = onboardingRankingRequestsService.deleteByInitiativeId(initiativeId);
+        List<OnboardingRankingRequests> result = onboardingRankingRequestsService.deletePaged(initiativeId, pageSize);
 
         // Then
         Assertions.assertNotNull(result);
@@ -57,6 +58,6 @@ class OnboardingRankingRequestsServiceImplTest {
         Assertions.assertEquals(onboardingRankingRequest.getAdmissibilityCheckDate(), result.get(0).getAdmissibilityCheckDate());
         Assertions.assertEquals(onboardingRankingRequest.getCriteriaConsensusTimestamp(), result.get(0).getCriteriaConsensusTimestamp());
         Assertions.assertEquals(onboardingRankingRequest.getRankingValue(), result.get(0).getRankingValue());
-        Mockito.verify(onboardingRankingRequestsRepositoryMock, Mockito.times(1)).deleteByInitiativeId(initiativeId);
+        Mockito.verify(onboardingRankingRequestsRepositoryMock, Mockito.times(1)).deletePaged(initiativeId, pageSize);
     }
 }

--- a/src/test/java/it/gov/pagopa/ranking/service/initiative/InitiativePersistenceMediatorImplTest.java
+++ b/src/test/java/it/gov/pagopa/ranking/service/initiative/InitiativePersistenceMediatorImplTest.java
@@ -17,14 +17,20 @@ import it.gov.pagopa.ranking.utils.AuditUtilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.support.MessageBuilder;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class InitiativePersistenceMediatorImplTest {
@@ -48,6 +54,14 @@ class InitiativePersistenceMediatorImplTest {
 
     @Mock
     private AuditUtilities auditUtilities;
+
+    private static final String ONBOARDING_RANKING_REQUEST_ID = "REQUEST_ID";
+    private static final String OPERATION_TYPE_DELETE_INITIATIVE = "DELETE_INITIATIVE";
+    private static final String INITIATIVE_ID = "TEST_INITIATIVE_ID";
+    private static final String PAGINATION_KEY = "pagination";
+    private static final String PAGINATION_VALUE = "100";
+    private static final String DELAY_KEY = "delay";
+    private static final String DELAY_VALUE = "1500";
 
     @BeforeEach
     void setUp(){
@@ -172,69 +186,75 @@ class InitiativePersistenceMediatorImplTest {
         Mockito.verify(rankingContextHolderServiceMock, Mockito.never()).setInitiativeConfig(Mockito.any());
     }
 
-    @Test
-    void processCommand_commandNotDeleteInitiative(){
+    @ParameterizedTest
+    @MethodSource("operationTypeAndInvocationTimes")
+    void processCommand(String operationType, int times) {
         // Given
-        QueueCommandOperationDTO queueCommandOperationDTO = QueueCommandOperationDTO.builder()
-                .entityId("EntityId")
-                .operationType("NOT_DELETE_INITIATIVE")
+        Map<String, String> additionalParams = new HashMap<>();
+        additionalParams.put(PAGINATION_KEY, PAGINATION_VALUE);
+        additionalParams.put(DELAY_KEY, DELAY_VALUE);
+        final QueueCommandOperationDTO queueCommandOperationDTO = QueueCommandOperationDTO.builder()
+                .entityId(INITIATIVE_ID)
+                .operationType(operationType)
+                .operationTime(LocalDateTime.now().minusMinutes(5))
+                .additionalParams(additionalParams)
                 .build();
-
-        // When
-        initiativePersistenceMediator.processCommand(queueCommandOperationDTO);
-
-        // Then
-        Mockito.verify(initiativeConfigServiceMock, Mockito.never()).deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
-        Mockito.verify(onboardingRankingRequestsServiceMock, Mockito.never()).deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
-    }
-
-    @Test
-    void processCommand_emptyDeletedInitiativeConfig(){
-        // Given
-        QueueCommandOperationDTO queueCommandOperationDTO = QueueCommandOperationDTO.builder()
-                .entityId("EntityId")
-                .operationType("DELETE_INITIATIVE")
-                .build();
-        Mockito.when(initiativeConfigServiceMock.deleteByInitiativeId(Mockito.any()))
-                .thenReturn(Optional.empty());
-
-        // When
-        initiativePersistenceMediator.processCommand(queueCommandOperationDTO);
-
-        // Then
-        Mockito.verify(initiativeConfigServiceMock, Mockito.times(1)).deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
-        Mockito.verify(onboardingRankingRequestsServiceMock, Mockito.times(1)).deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
-
-    }
-
-    @Test
-    void processCommand(){
-        // Given
-        QueueCommandOperationDTO queueCommandOperationDTO = QueueCommandOperationDTO.builder()
-                .entityId("EntityId")
-                .operationType("DELETE_INITIATIVE")
+        OnboardingRankingRequests onboardingRankingRequest = OnboardingRankingRequests.builder()
+                .id(ONBOARDING_RANKING_REQUEST_ID)
+                .initiativeId(INITIATIVE_ID)
                 .build();
         InitiativeConfig initiativeConfig = InitiativeConfig.builder()
-                .initiativeId(queueCommandOperationDTO.getEntityId())
+                .initiativeId(INITIATIVE_ID)
                 .initiativeName("InitiativeName")
                 .build();
-        OnboardingRankingRequests onboardingRankingRequests = OnboardingRankingRequests.builder()
-                .id("Id")
-                .userId("UserId")
-                .initiativeId(queueCommandOperationDTO.getEntityId())
-                .organizationId("OrganizationId")
-                .build();
-        Mockito.when(initiativeConfigServiceMock.deleteByInitiativeId(Mockito.any()))
-                .thenReturn(Optional.of(initiativeConfig));
-        Mockito.when(onboardingRankingRequestsServiceMock.deleteByInitiativeId(Mockito.any()))
-                .thenReturn(List.of(onboardingRankingRequests));
+        final List<OnboardingRankingRequests> deletedPage = List.of(onboardingRankingRequest);
+
+        if(times == 2){
+            final List<OnboardingRankingRequests> onboardingRankingRequestPage = createOnboardingRankingRequestPage(Integer.parseInt(PAGINATION_VALUE));
+            when(onboardingRankingRequestsServiceMock.deletePaged(queueCommandOperationDTO.getEntityId(), Integer.parseInt(queueCommandOperationDTO.getAdditionalParams().get(PAGINATION_KEY))))
+                    .thenReturn(onboardingRankingRequestPage)
+                    .thenReturn(deletedPage);
+            Mockito.when(initiativeConfigServiceMock.deleteByInitiativeId(Mockito.any()))
+                    .thenReturn(Optional.empty());
+        } else if (times == 1) {
+            when(onboardingRankingRequestsServiceMock.deletePaged(queueCommandOperationDTO.getEntityId(), Integer.parseInt(queueCommandOperationDTO.getAdditionalParams().get(PAGINATION_KEY))))
+                    .thenReturn(deletedPage);
+            Mockito.when(initiativeConfigServiceMock.deleteByInitiativeId(Mockito.any()))
+                    .thenReturn(Optional.of(initiativeConfig));
+        }
+
 
         // When
+        if(times == 2){
+            Thread.currentThread().interrupt();
+        }
         initiativePersistenceMediator.processCommand(queueCommandOperationDTO);
 
+
         // Then
-        Mockito.verify(initiativeConfigServiceMock, Mockito.times(1)).deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
-        Mockito.verify(onboardingRankingRequestsServiceMock, Mockito.times(1)).deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
+        Mockito.verify(initiativeConfigServiceMock, Mockito.times(times == 0 ? 0 : 1)).deleteByInitiativeId(queueCommandOperationDTO.getEntityId());
+        Mockito.verify(onboardingRankingRequestsServiceMock, Mockito.times(times)).deletePaged(queueCommandOperationDTO.getEntityId(), Integer.parseInt(queueCommandOperationDTO.getAdditionalParams().get(PAGINATION_KEY)));
+    }
+
+    private static Stream<Arguments> operationTypeAndInvocationTimes() {
+        return Stream.of(
+                Arguments.of(OPERATION_TYPE_DELETE_INITIATIVE, 1),
+                Arguments.of(OPERATION_TYPE_DELETE_INITIATIVE, 2),
+                Arguments.of("OPERATION_TYPE_TEST", 0)
+        );
+    }
+
+    private List<OnboardingRankingRequests> createOnboardingRankingRequestPage(int pageSize){
+        List<OnboardingRankingRequests> onboardingRankingRequestPage = new ArrayList<>();
+
+        for(int i=0;i<pageSize; i++){
+            onboardingRankingRequestPage.add(OnboardingRankingRequests.builder()
+                    .id(ONBOARDING_RANKING_REQUEST_ID+i)
+                    .initiativeId(INITIATIVE_ID)
+                    .build());
+        }
+
+        return onboardingRankingRequestPage;
     }
 
     private InitiativeConfig getInitiativeConfigExpected(InitiativeBuildDTO initiativeRequest) {

--- a/src/test/java/it/gov/pagopa/ranking/service/initiative/InitiativePersistenceMediatorImplTest.java
+++ b/src/test/java/it/gov/pagopa/ranking/service/initiative/InitiativePersistenceMediatorImplTest.java
@@ -223,13 +223,11 @@ class InitiativePersistenceMediatorImplTest {
                     .thenReturn(Optional.of(initiativeConfig));
         }
 
-
         // When
         if(times == 2){
             Thread.currentThread().interrupt();
         }
         initiativePersistenceMediator.processCommand(queueCommandOperationDTO);
-
 
         // Then
         Mockito.verify(initiativeConfigServiceMock, Mockito.times(times == 0 ? 0 : 1)).deleteByInitiativeId(queueCommandOperationDTO.getEntityId());


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The purpose of this pr is to change the method of deletion from the database from a bulk delete to a paged delete.

#### List of Changes
<!--- Describe your changes in detail -->
- Modified QueueCommandOperationDTO
- Added paged delete method to extended repository
- Modified JUnit tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [X] Unit
    - [ ] Integration (Narrow)
- Post-Deploy Test
    - [X] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
